### PR TITLE
Coverage Plugin - project code structure:

### DIFF
--- a/plugins/drill-coverage-plugin/src/adminPartMain/kotlin/CoverageController.kt
+++ b/plugins/drill-coverage-plugin/src/adminPartMain/kotlin/CoverageController.kt
@@ -1,4 +1,4 @@
-package com.epam.drill.plugins.custom
+package com.epam.drill.plugins.coverage
 
 
 import com.epam.drill.plugin.api.end.AdminPluginPart

--- a/plugins/drill-coverage-plugin/src/agentPartMain/kotlin/CoverageAgentPart.kt
+++ b/plugins/drill-coverage-plugin/src/agentPartMain/kotlin/CoverageAgentPart.kt
@@ -1,4 +1,4 @@
-package com.epam.drill.plugins.custom
+package com.epam.drill.plugins.coverage
 
 import com.epam.drill.plugin.api.processing.InstrumentedPlugin
 import com.epam.drill.plugin.api.processing.Sender

--- a/plugins/drill-coverage-plugin/src/agentPartMain/kotlin/CoverageInstrumentation.kt
+++ b/plugins/drill-coverage-plugin/src/agentPartMain/kotlin/CoverageInstrumentation.kt
@@ -1,4 +1,4 @@
-package com.epam.drill.plugins.custom
+package com.epam.drill.plugins.coverage
 
 import org.jacoco.core.instr.Instrumenter
 import org.jacoco.core.internal.data.CRC64

--- a/plugins/drill-coverage-plugin/src/agentPartTest/kotlin/CoverageInstrumentationTest.kt
+++ b/plugins/drill-coverage-plugin/src/agentPartTest/kotlin/CoverageInstrumentationTest.kt
@@ -1,4 +1,4 @@
-package com.epam.drill.plugins.custom
+package com.epam.drill.plugins.coverage
 
 import org.jacoco.core.analysis.Analyzer
 import org.jacoco.core.analysis.CoverageBuilder

--- a/plugins/drill-coverage-plugin/src/commonMain/kotlin/Data.kt
+++ b/plugins/drill-coverage-plugin/src/commonMain/kotlin/Data.kt
@@ -1,4 +1,4 @@
-package com.epam.drill.plugins.custom
+package com.epam.drill.plugins.coverage
 
 
 @kotlinx.serialization.Serializable


### PR DESCRIPTION
- changed base package to com.epam.drill.plugins.coverage
- simplified directory tree - omitted root package (Kotlin coding conventions)