### PR TITLE
EPMDJ-43. Changed pluginStorage from MutableMap to ConcurrentHashMap

### DIFF
--- a/drill-admin/src/main/kotlin/com/epam/drill/endpoints/plugin/DrillPluginWs.kt
+++ b/drill-admin/src/main/kotlin/com/epam/drill/endpoints/plugin/DrillPluginWs.kt
@@ -31,7 +31,7 @@ private val logger = KotlinLogging.logger {}
 
 class DrillPluginWs(override val kodein: Kodein) : KodeinAware, WsService {
 
-    private val pluginStorage: MutableMap<String, Any> = mutableMapOf()
+    private val pluginStorage: ConcurrentHashMap<String, Any> = ConcurrentHashMap()
     private val app: Application by instance()
     private val cacheService: CacheService by instance()
     private val eventStorage: Cache<String, String> by cacheService

--- a/plugins/drill-coverage-plugin/src/adminPartTest/kotlin/CoverageControllerTest.kt
+++ b/plugins/drill-coverage-plugin/src/adminPartTest/kotlin/CoverageControllerTest.kt
@@ -14,6 +14,8 @@ import com.epam.drill.plugins.coverage.test.bar.BarDummy
 import com.epam.drill.plugins.coverage.test.foo.FooDummy
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.list
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -147,7 +149,7 @@ class CoverageControllerTest {
 
 class WsServiceStub : WsService {
 
-    private val pluginStorage: MutableMap<String, Any> = mutableMapOf()
+    private val pluginStorage: ConcurrentHashMap<String, Any> = ConcurrentHashMap()
     val sent = mutableListOf<Pair<String, Any>>()
 
     lateinit var javaPackagesCoverage: List<JavaPackageCoverage>


### PR DESCRIPTION
Changed pluginStorage from MutableMap to ConcurrentHashMap to avoid possible thread conflicts