### PR TITLE
EPMDJ-398. Added coverage plugin to drill admin docker image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,12 @@ pipeline:
     image: gradle:5.4.1-jdk8
     secrets: [ drill_username, drill_password ]
     commands:
-      - gradle :drill-admin:jib -Djib.to.auth.username=$${DRILL_USERNAME} -Djib.to.auth.password=$${DRILL_PASSWORD}
+      - gradle buildCoveragePluginDev
+      - gradle :drill-admin:jib\
+        -Djib.to.auth.username=$${DRILL_USERNAME}\
+        -Djib.to.auth.password=$${DRILL_PASSWORD}\
+        -Djib.to.tags=coverage-latest\
+        -Djib.extraDirectories.paths=/home/gradle/distr
     when:
       branch:
         - develop

--- a/drill-admin/build.gradle.kts
+++ b/drill-admin/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.epam.drill.build.*
+import com.google.cloud.tools.jib.plugins.common.*
 import org.jetbrains.kotlin.gradle.tasks.*
 
 plugins {
@@ -61,13 +62,19 @@ dependencies {
 
 }
 
+println(jib.extraDirectories.paths.map { it.toAbsolutePath().toString() })
+println(project.getProperties()["jib.extraDirectories.paths"])
+println( System.getProperty(PropertyNames.EXTRA_DIRECTORIES_PATHS))
+println( System.getProperty(PropertyNames.TO_TAGS))
+
 jib {
     from {
         image = "gcr.io/distroless/java:8"
     }
     to {
         image = "drill4j/${project.name}"
-        tags = mutableSetOf("latest")
+        auth.username="drill4j"
+        auth.password="ZBoDXn4t1"
     }
     container {
         ports = listOf("8090", "5006")

--- a/drill-admin/gradle.properties
+++ b/drill-admin/gradle.properties
@@ -1,0 +1,3 @@
+jib.to.tags=latest
+#jib.to.tags=coverage-latest
+jib.extraDirectories.paths=C:\\Users\\Kristina_Smirnova\\Documents\\drill\\Drill4J\\distr


### PR DESCRIPTION
Tags for this image are "latest" and "with-coverage-plugin"