### PR TITLE
EPMDJ-526. Refactored calculateCoverageData(..)

### DIFF
--- a/plugins/drill-coverage-plugin/src/adminPartMain/kotlin/Scope.kt
+++ b/plugins/drill-coverage-plugin/src/adminPartMain/kotlin/Scope.kt
@@ -19,6 +19,8 @@ class ActiveScope(
     
     val summary get() = _summary.value
 
+    val sessions get() = _sessions.value
+
     val sessionCount get() = _sessions.value.count()
     
     val probes get() = _sessions.value.asSequence().flatten()


### PR DESCRIPTION
Refactored calculateCoverageData(..) to take not a scope, but a FinishedSession sequence as argument. The ActiveScope argument is now optional (only for evaluating the arrow type)