### PR TITLE
EPMDJ-526. Refactored calculateCoverageData(..) 

### DIFF
--- a/plugins/drill-coverage-plugin/src/adminPartMain/kotlin/CoverageAdminPart.kt
+++ b/plugins/drill-coverage-plugin/src/adminPartMain/kotlin/CoverageAdminPart.kt
@@ -104,15 +104,16 @@ class CoverageAdminPart(sender: Sender, agentInfo: AgentInfo, id: String) :
         return ""
     }
 
-    internal fun calculateCoverageData(scope: ActiveScope): CoverageInfoSet {
+    internal fun calculateCoverageData(finishedSessions: Sequence<FinishedSession>): CoverageInfoSet {
+        val probes = finishedSessions.flatten()
         val classesData = agentState.classesData()
         // Analyze all existing classes
         val coverageBuilder = CoverageBuilder()
-        val dataStore = ExecutionDataStore().with(scope.probes)
+        val dataStore = ExecutionDataStore().with(probes)
         val initialClassBytes = classesData.classesBytes
         val analyzer = Analyzer(dataStore, coverageBuilder)
 
-        val scopeProbes = scope.probes.toList()
+        val scopeProbes = probes.toList()
         val assocTestsMap = getAssociatedTestMap(scopeProbes, initialClassBytes)
         val associatedTests = assocTestsMap.getAssociatedTests()
 
@@ -121,8 +122,6 @@ class CoverageAdminPart(sender: Sender, agentInfo: AgentInfo, id: String) :
         }
         val bundleCoverage = coverageBuilder.getBundle("")
         val totalCoveragePercent = bundleCoverage.coverage(classesData.totals.instructionCounter.totalCount)
-        // change arrow indicator (increase, decrease)
-        val arrow = scope.arrowType(totalCoveragePercent)
 
         val classesCount = classesData.totals.classCounter.totalCount
         val methodsCount = classesData.totals.methodCounter.totalCount
@@ -131,8 +130,7 @@ class CoverageAdminPart(sender: Sender, agentInfo: AgentInfo, id: String) :
             coverage = totalCoveragePercent,
             classesCount = classesCount,
             methodsCount = methodsCount,
-            uncoveredMethodsCount = uncoveredMethodsCount,
-            arrow = arrow
+            uncoveredMethodsCount = uncoveredMethodsCount
         )
         println(coverageBlock)
 


### PR DESCRIPTION
Refactored calculateCoverageData(..) to take not a scope, but a FinishedSession sequence as argument